### PR TITLE
resets altDown and mouse events on focusout event

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -61,6 +61,12 @@ module.exports =
         e.preventDefault()
         return false
 
+    onFocusOut = (e) =>
+      altDown    = false
+      mouseStart = null
+      mouseEnd   = null
+      columnWidth  = null
+
     # I had to create my own version of editorView.screenPositionFromMouseEvent
     # The editorView one doesnt quite do what I need
     overflowableScreenPositionFromMouseEvent = (e) =>
@@ -99,5 +105,6 @@ module.exports =
     @subscribe editorView, 'mouseup',    onMouseUp
     @subscribe editorView, 'mousemove',  onMouseMove
     @subscribe editorView, 'mouseleave', onMouseleave
+    @subscribe editorView, 'focusout',   onFocusOut
 
 Subscriber.extend module.exports


### PR DESCRIPTION
Possible fix for #16 and #17, seems to work for me
