### PR TITLE
Fixed off-by-one in column selection area.

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -79,7 +79,7 @@ module.exports =
         for row in [mouseStart.row..mouseEnd.row]
           # Define a range for this row from the mouseStart column number to
           # the mouseEnd column number
-          range = editor.bufferRangeForScreenRange [[row, mouseStart.column], [row, mouseEnd.column]]
+          range = editor.bufferRangeForScreenRange [[row, mouseStart.column-1], [row, mouseEnd.column-1]]
 
           allRanges.push range
           if editor.getTextInBufferRange(range).length > 0


### PR DESCRIPTION
I find the selection is always 1 column to the right of where I am selecting. This moves the selection the the left.
