### PR TITLE
Multiplatform support, use e.[some]Key instead of tracking key state, middle click

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -103,8 +103,6 @@ module.exports =
           editor.setSelectedBufferRanges allRanges
 
     # Subscribe to the various things
-    @subscribe editorView, 'keydown',     onKeyDown
-    @subscribe editorView, 'keyup',       onKeyUp
     @subscribe editorView, 'mousedown',   onMouseDown
     @subscribe editorView, 'mouseup',     onMouseUp
     @subscribe editorView, 'mousemove',   onMouseMove


### PR DESCRIPTION
On linux sublime uses shift+rightclick for the multiselection (since the alt key is mostly reserved for the window manager).

I added support for linux and windows too (untested) according to these sublime docs https://www.sublimetext.com/docs/2/column_selection.html

In the process I switched to use e.altKey or e.shiftKey instead of keeping track of the key state since it was giving me issues when alt-clicking on another window from Atom.

I also added support for middle click on mac and windows (sortof untested).
