### PR TITLE
Fix, provide case for 'win32'

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -1,6 +1,10 @@
 os = require 'os'
 
 inputCfg = switch os.platform()
+  when 'win32'
+    key: 'altKey'
+    mouse: 1
+    middleMouse: true
   when 'darwin'
     key: 'altKey'
     mouse: 1


### PR DESCRIPTION
The os.platform() return value must have changed recently? This change looks like it makes it work as intended on my machine. I'm running Windows 7 64bit.
