### PR TITLE
Fix deprecation warning, code style and a small typo

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -35,11 +35,11 @@ module.exports =
     mouseStart  = null
     mouseEnd    = null
 
-    resetState = =>
+    resetState = ->
       mouseStart  = null
       mouseEnd    = null
 
-    onMouseDown = (e) =>
+    onMouseDown = (e) ->
       if mouseStart
         e.preventDefault()
         return false
@@ -51,7 +51,7 @@ module.exports =
         e.preventDefault()
         return false
 
-    onMouseMove = (e) =>
+    onMouseMove = (e) ->
       if mouseStart
         if (inputCfg.middleMouse and e.which is 2) or (e.which is inputCfg.mouse)
           mouseEnd = _screenPositionForMouseEvent(e)
@@ -62,17 +62,17 @@ module.exports =
           resetState()
 
     # Hijack all the mouse events when selecting
-    hijackMouseEvent = (e) =>
+    hijackMouseEvent = (e) ->
       if mouseStart
         e.preventDefault()
         return false
 
-    onBlur = (e) =>
+    onBlur = (e) ->
       resetState()
 
     # I had to create my own version of editorComponent.screenPositionFromMouseEvent
     # The editorBuffer one doesnt quite do what I need
-    _screenPositionForMouseEvent = (e) =>
+    _screenPositionForMouseEvent = (e) ->
       pixelPosition    = editorComponent.pixelPositionForMouseEvent(e)
       targetTop        = pixelPosition.top
       targetLeft       = pixelPosition.left
@@ -85,7 +85,7 @@ module.exports =
       return {row: row, column: column}
 
     # Do the actual selecting
-    selectBoxAroundCursors = =>
+    selectBoxAroundCursors = ->
       if mouseStart and mouseEnd
         allRanges = []
         rangesWithLength = []

--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -62,7 +62,7 @@ module.exports =
           resetState()
 
     # Hijack all the mouse events when selecting
-    hikackMouseEvent = (e) =>
+    hijackMouseEvent = (e) =>
       if mouseStart
         e.preventDefault()
         return false
@@ -109,8 +109,8 @@ module.exports =
     # Subscribe to the various things
     editorElement.onmousedown   = onMouseDown
     editorElement.onmousemove   = onMouseMove
-    editorElement.onmouseup     = hikackMouseEvent
-    editorElement.onmouseleave  = hikackMouseEvent
-    editorElement.onmouseenter  = hikackMouseEvent
-    editorElement.oncontextmenu = hikackMouseEvent
+    editorElement.onmouseup     = hijackMouseEvent
+    editorElement.onmouseleave  = hijackMouseEvent
+    editorElement.onmouseenter  = hijackMouseEvent
+    editorElement.oncontextmenu = hijackMouseEvent
     editorElement.onblur        = onBlur

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/sublime-select",
   "version": "1.2.3",
   "description": "Enable Sublime style 'Column Selection'. Just hold 'alt' while you select. Also similar to Texmate's 'Multiple Carets', or BBEdit's 'Block Select'",
-  "activationEvents": [],
+  "activationCommands": [],
   "repository": "https://github.com/bigfive/atom-sublime-select",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Mainly fix deprecation warning, but also removed unnecessary fat arrows and a small typo.
Fix #42, #44, #46, #47, #48

Please let me know if something is missing :smile: 
/Carl
