### PR TITLE
Change from middle to left mouse button

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -13,7 +13,7 @@ inputCfg = switch os.platform()
     enableMiddleMouse: true
   when 'linux'
     selectKey: 'shiftKey'
-    mainMouseNum: 2
+    mainMouseNum: 1
     middleMouseNum: 2
     enableMiddleMouse: false
   else


### PR DESCRIPTION
Hi,
In Ubuntu (I think all linux), the middle button past what is in copy buffer. Sublime on Ubuntu use the right button to select column. I think it's not possible on atom, so i change it to left button. 