### PR TITLE
fix uncaught type error from editorComponent

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -82,6 +82,9 @@ module.exports =
     # I had to create my own version of editorComponent.screenPositionFromMouseEvent
     # The editorBuffer one doesnt quite do what I need
     _screenPositionForMouseEvent = (e) ->
+      if editorComponent is null
+        editorComponent = atom.views.getView(editor).component
+        
       pixelPosition    = editorComponent.pixelPositionForMouseEvent(e)
       targetTop        = pixelPosition.top
       targetLeft       = pixelPosition.left


### PR DESCRIPTION
Hi there!

This is a fix for issue #63

Occasionally, while using the editor, `editorComponent` is reset to null. I wasn't able to find the root cause of this behavior, but by calling `getView` and accessing the component from within the event callback, I can reliably retrieve a `TextEditorComponent` object, which prevents the type error.