### PR TITLE
Refactor and fix multi pane issue

### DIFF
--- a/lib/editor-handler.coffee
+++ b/lib/editor-handler.coffee
@@ -1,0 +1,137 @@
+module.exports =
+  class SublimeSelectEditorHandler
+    constructor: (editor, inputCfg) ->
+      @editor = editor
+      @inputCfg = inputCfg
+      @_resetState()
+      @_setup_vars()
+
+    subscribe: ->
+      @selection_observer = @editor.onDidChangeSelectionRange @onRangeChange
+      @editorElement.addEventListener 'mousedown',   @onMouseDown
+      @editorElement.addEventListener 'mousemove',   @onMouseMove
+      @editorElement.addEventListener 'keydown',     @onKeyDown
+      @editorElement.addEventListener 'keyup',       @onKeyUp
+      @editorElement.addEventListener 'mouseup',     @onMouseEventToHijack
+      @editorElement.addEventListener 'mouseleave',  @onMouseEventToHijack
+      @editorElement.addEventListener 'mouseenter',  @onMouseEventToHijack
+      @editorElement.addEventListener 'contextmenu', @onMouseEventToHijack
+      @editorElement.addEventListener 'blur',        @onBlur
+
+    unsubscribe: ->
+      @_resetState()
+      @selection_observer.dispose()
+      @editorElement.removeEventListener 'mousedown',   @onMouseDown
+      @editorElement.removeEventListener 'mousemove',   @onMouseMove
+      @editorElement.removeEventListener 'keydown',     @onKeyDown
+      @editorElement.removeEventListener 'keyup',       @onKeyUp
+      @editorElement.removeEventListener 'mouseup',     @onMouseEventToHijack
+      @editorElement.removeEventListener 'mouseleave',  @onMouseEventToHijack
+      @editorElement.removeEventListener 'mouseenter',  @onMouseEventToHijack
+      @editorElement.removeEventListener 'contextmenu', @onMouseEventToHijack
+      @editorElement.removeEventListener 'blur',        @onBlur
+
+    # -------
+    # Event Handlers
+    # -------
+
+    onMouseDown: (e) =>
+      if @mouseStartPos
+        e.preventDefault()
+        return false
+
+      if @_mainMouseAndKeyDown(e)
+        @_resetState()
+        @mouseStartPos = @_screenPositionForMouseEvent(e)
+        @mouseEndPos   = @mouseStartPos
+        e.preventDefault()
+        return false
+
+    onMouseMove: (e) =>
+      if @mouseStartPos
+        e.preventDefault()
+        if @_mainMouseDown(e)
+          @mouseEndPos = @_screenPositionForMouseEvent(e)
+          @_selectBoxAroundCursors()
+          return false
+        if e.which == 0
+          @_resetState()
+
+    onKeyDown: (e) =>
+      if e['keyIdentifier'] == @inputCfg.selectKeyName and e['type'] == 'keydown'
+        @editorElement.style.cursor = 'crosshair'
+
+    onKeyUp: (e) =>
+      if e['keyIdentifier'] == @inputCfg.selectKeyName and e['type'] == 'keyup'
+        @editorElement.style.cursor = ''
+
+    # Hijack all the mouse events while selecting
+    onMouseEventToHijack: (e) =>
+      if @mouseStartPos
+        e.preventDefault()
+        return false
+
+    onBlur: (e) =>
+      @_resetState()
+
+    onRangeChange: (newVal) =>
+      if @mouseStartPos and !newVal.selection.isSingleScreenLine()
+        newVal.selection.destroy()
+        @_selectBoxAroundCursors()
+
+    # -------
+    # Methods
+    # -------
+
+    _resetState: ->
+      @mouseStartPos = null
+      @mouseEndPos   = null
+
+    _setup_vars: ->
+      @editorBuffer ?= @editor.displayBuffer
+      @editorElement ?= atom.views.getView @editor
+      @editorComponent ?= @editorElement.component
+
+    # I had to create my own version of @editorComponent.screenPositionFromMouseEvent
+    # The @editorBuffer one doesnt quite do what I need
+    _screenPositionForMouseEvent: (e) ->
+      @_setup_vars()
+      pixelPosition    = @editorComponent.pixelPositionForMouseEvent(e)
+      targetTop        = pixelPosition.top
+      targetLeft       = pixelPosition.left
+      defaultCharWidth = @editorBuffer.defaultCharWidth
+      row              = Math.floor(targetTop / @editorBuffer.getLineHeightInPixels())
+      targetLeft       = Infinity if row > @editorBuffer.getLastRow()
+      row              = Math.min(row, @editorBuffer.getLastRow())
+      row              = Math.max(0, row)
+      column           = Math.round (targetLeft) / defaultCharWidth
+      return {row: row, column: column}
+
+    # methods for checking mouse/key state against config
+    _mainMouseDown: (e) ->
+      e.which is @inputCfg.mouseNum
+
+    _mainMouseAndKeyDown: (e) ->
+      @_mainMouseDown(e) and e[@inputCfg.selectKey]
+
+    # Do the actual selecting
+    _selectBoxAroundCursors: ->
+      if @mouseStartPos and @mouseEndPos
+        allRanges = []
+        rangesWithLength = []
+
+        for row in [@mouseStartPos.row..@mouseEndPos.row]
+          # Define a range for this row from the @mouseStartPos column number to
+          # the @mouseEndPos column number
+          range = [[row, @mouseStartPos.column], [row, @mouseEndPos.column]]
+
+          allRanges.push range
+          if @editor.getTextInBufferRange(range).length > 0
+            rangesWithLength.push range
+
+        # If there are ranges with text in them then only select those
+        # Otherwise select all the 0 length ranges
+        if rangesWithLength.length
+          @editor.setSelectedScreenRanges rangesWithLength
+        else if allRanges.length
+          @editor.setSelectedScreenRanges allRanges

--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -1,6 +1,7 @@
-os = require 'os'
-
 packageName = "Sublime-Style-Column-Selection"
+
+os = require 'os'
+SublimeSelectEditorHandler = require './editor-handler.coffee'
 
 defaultCfg = switch os.platform()
   when 'win32'
@@ -37,6 +38,7 @@ selectKeyMap =
 inputCfg = defaultCfg
 
 module.exports =
+
   config:
     mouseButtonTrigger:
       title: "Mouse Button"
@@ -54,123 +56,27 @@ module.exports =
       default: defaultCfg.selectKeyName
 
   activate: (state) ->
-    atom.config.observe "#{packageName}.mouseButtonTrigger", (newValue) =>
+    @observers = []
+    @editor_handler = null
+
+    @observers.push atom.config.observe "#{packageName}.mouseButtonTrigger", (newValue) =>
       inputCfg.mouseName = newValue
       inputCfg.mouseNum = mouseNumMap[newValue]
 
-    atom.config.observe "#{packageName}.selectKeyTrigger", (newValue) =>
+    @observers.push atom.config.observe "#{packageName}.selectKeyTrigger", (newValue) =>
       inputCfg.selectKeyName = newValue
       inputCfg.selectKey = selectKeyMap[newValue]
 
-    atom.workspace.observeTextEditors (editor) =>
-      @_handleLoad editor
+    @observers.push atom.workspace.observeActivePane @switch_editor_handler
+    @observers.push atom.workspace.onDidAddPane      @switch_editor_handler
+    @observers.push atom.workspace.onDidDestroyPane  @switch_editor_handler
 
   deactivate: ->
-    @unsubscribe()
+    observer.dispose() for observer in @observers
+    @editor_handler.unsubscribe()
 
-  _handleLoad: (editor) ->
-    editorBuffer = editor.displayBuffer
-    editorElement = atom.views.getView editor
-    editorComponent = editorElement.component
-
-    mouseStartPos  = null
-    mouseEndPos    = null
-
-    resetState = ->
-      mouseStartPos  = null
-      mouseEndPos    = null
-
-    onMouseDown = (e) ->
-      if mouseStartPos
-        e.preventDefault()
-        return false
-
-      if _mainMouseAndKeyDown(e)
-        resetState()
-        mouseStartPos = _screenPositionForMouseEvent(e)
-        mouseEndPos   = mouseStartPos
-        e.preventDefault()
-        return false
-
-    onMouseMove = (e) ->
-      if mouseStartPos
-        e.preventDefault()
-        if _mainMouseDown(e)
-          mouseEndPos = _screenPositionForMouseEvent(e)
-          _selectBoxAroundCursors()
-          return false
-        if e.which == 0
-          resetState()
-
-    # Hijack all the mouse events while selecting
-    hijackMouseEvent = (e) ->
-      if mouseStartPos
-        e.preventDefault()
-        return false
-
-    onBlur = (e) ->
-      resetState()
-
-    onRangeChange = (newVal) ->
-      if mouseStartPos and !newVal.selection.isSingleScreenLine()
-        newVal.selection.destroy()
-        _selectBoxAroundCursors()
-
-    # I had to create my own version of editorComponent.screenPositionFromMouseEvent
-    # The editorBuffer one doesnt quite do what I need
-    _screenPositionForMouseEvent = (e) ->
-      if editorComponent is null
-        editorComponent = atom.views.getView(editor).component
-        
-      pixelPosition    = editorComponent.pixelPositionForMouseEvent(e)
-      targetTop        = pixelPosition.top
-      targetLeft       = pixelPosition.left
-      defaultCharWidth = editorBuffer.defaultCharWidth
-      row              = Math.floor(targetTop / editorBuffer.getLineHeightInPixels())
-      targetLeft       = Infinity if row > editorBuffer.getLastRow()
-      row              = Math.min(row, editorBuffer.getLastRow())
-      row              = Math.max(0, row)
-      column           = Math.round (targetLeft) / defaultCharWidth
-      return {row: row, column: column}
-
-    # methods for checking mouse/key state against config
-    _mainMouseDown = (e) ->
-      e.which is inputCfg.mouseNum
-
-    _keyDown = (e) ->
-      e[inputCfg.selectKey]
-
-    _mainMouseAndKeyDown = (e) ->
-      _mainMouseDown(e) and e[inputCfg.selectKey]
-
-    # Do the actual selecting
-    _selectBoxAroundCursors = ->
-      if mouseStartPos and mouseEndPos
-        allRanges = []
-        rangesWithLength = []
-
-        for row in [mouseStartPos.row..mouseEndPos.row]
-          # Define a range for this row from the mouseStartPos column number to
-          # the mouseEndPos column number
-          range = [[row, mouseStartPos.column], [row, mouseEndPos.column]]
-
-          allRanges.push range
-          if editor.getTextInBufferRange(range).length > 0
-            rangesWithLength.push range
-
-        # If there are ranges with text in them then only select those
-        # Otherwise select all the 0 length ranges
-        if rangesWithLength.length
-          editor.setSelectedScreenRanges rangesWithLength
-        else if allRanges.length
-          editor.setSelectedScreenRanges allRanges
-
-    # Subscribe to the various things
-    editor.onDidChangeSelectionRange onRangeChange
-    editorElement.onmousedown   = onMouseDown
-    editorElement.onmousemove   = onMouseMove
-    editorElement.onmouseup     = hijackMouseEvent
-    editorElement.onmouseleave  = hijackMouseEvent
-    editorElement.onmouseenter  = hijackMouseEvent
-    editorElement.oncontextmenu = hijackMouseEvent
-    editorElement.onblur        = onBlur
+  switch_editor_handler: =>
+    @editor_handler?.unsubscribe()
+    active_editor = atom.workspace.getActiveTextEditor()
+    @editor_handler = new SublimeSelectEditorHandler(active_editor, inputCfg)
+    @editor_handler.subscribe()


### PR DESCRIPTION
Big PR for fixing multi pane issue and extracting out a SublimeSelectEditorHandler class

The mutipane fix is to expand what we observe on the workspace:

```ruby
-    atom.workspace.observeTextEditors (editor) =>
-      @_handleLoad editor
+    @observers.push atom.workspace.observeActivePane @switch_editor_handler
+    @observers.push atom.workspace.onDidAddPane      @switch_editor_handler
+    @observers.push atom.workspace.onDidDestroyPane  @switch_editor_handler
```