### PR TITLE
Added "Cmd Key" as an alternative to selectKeyMap

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -34,7 +34,10 @@ selectKeyMap =
   Shift: 'shiftKey',
   Alt:   'altKey',
   Ctrl:  'ctrlKey',
-  None:  null
+
+selectKeyMap.Cmd = 'metaKey' if os.platform() == 'darwin'
+
+selectKeyMap.None = null
 
 inputCfg = defaultCfg
 


### PR DESCRIPTION
This allows people on a Mac to use cmd to trigger the vertical select (I'm not sure what the "metaKey" maps to in other platforms).