### PR TITLE
Cleanly deactivate

### DIFF
--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -74,8 +74,10 @@ module.exports =
     @observers.push atom.workspace.onDidDestroyPane          @switch_editor_handler
 
   deactivate: ->
-    @editor_handler.unsubscribe()
+    @editor_handler?.unsubscribe()
     observer.dispose() for observer in @observers
+    @observers = null
+    @editor_handler = null
 
   switch_editor_handler: =>
     @editor_handler?.unsubscribe()


### PR DESCRIPTION
`editor_handler` maybe be null when no panes are open. Also, release any references to observers or editors so they may be garbage collected.