### PR TITLE
Partial fix for remove deprecated `displayBuffer` references

### DIFF
--- a/lib/editor-handler.coffee
+++ b/lib/editor-handler.coffee
@@ -80,7 +80,7 @@ module.exports =
       @mouseEndPos   = null
 
     _setup_vars: ->
-      @editorBuffer ?= @editor.displayBuffer
+
       @editorElement ?= atom.views.getView @editor
       @editorComponent ?= @editorElement.component
 
@@ -91,10 +91,10 @@ module.exports =
       pixelPosition    = @editorComponent.pixelPositionForMouseEvent(e)
       targetTop        = pixelPosition.top
       targetLeft       = pixelPosition.left
-      defaultCharWidth = @editorBuffer.defaultCharWidth
-      row              = Math.floor(targetTop / @editorBuffer.getLineHeightInPixels())
-      targetLeft       = Infinity if row > @editor.buffer.getLastRow()
-      row              = Math.min(row, @editor.buffer.getLastRow())
+      defaultCharWidth = @editor.getDefaultCharWidth()
+      row              = Math.floor(targetTop / @editor.getLineHeightInPixels())
+      targetLeft       = Infinity if row > @editor.getLastBufferRow()
+      row              = Math.min(row, @editor.getLastBufferRow())
       row              = Math.max(0, row)
       column           = Math.round (targetLeft) / defaultCharWidth
       new Point(row, column)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "Sublime-Style-Column-Selection",
   "main": "./lib/sublime-select",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Enable Sublime style 'Column Selection'. Just hold 'alt' while you select, or select using your middle mouse button. Also similar to Texmate's 'Multiple Carets', or BBEdit's 'Block Select'",
   "repository": "https://github.com/bigfive/atom-sublime-select",
   "license": "MIT",
   "engines": {
-    "atom": ">0.165.0"
+    "atom": ">1.12.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Removes references to the deprecated `displayBuffer` references that breaks Atom 1.13.  Fixes #133.  The column select behavior isn't quite right however.