### PR TITLE
Add crosshair cursor and or logic options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ You can require both a certain key & modifier, or trigger on either one.
 Optionally change cursor to crosshair when selecting.
 
 ### Change Cursor to Crosshair
-- true (default)
-- false
+- true
+- false (default)

--- a/README.md
+++ b/README.md
@@ -21,16 +21,24 @@ Default key combinations are:
 The modifier key and mouse button can both be configured from the package's settings page. Available options:
 
 ### Mouse Button
-- Left
+- Left (default)
 - Middle
 - Right
 
-### Key Trigger
-- Shift
-- Alt/Option
+### Key Trigger (default selected based on platform)
+- Shift (default on linux)
+- Alt/Option (default on win/mac)
 - Ctrl
 - None
 
-To use middle mouse selection working since version 1.4.0 please use the following settings.
+You can require both a certain key & modifier, or trigger on either one.
 
-![](https://cloud.githubusercontent.com/assets/633193/12469581/e829bcd0-c027-11e5-8104-901fc0ff4a73.png)
+### Logic Operator
+- And (default)
+- Or
+
+Optionally change cursor to crosshair when selecting.
+
+### Change Cursor to Crosshair
+- true (default)
+- false

--- a/lib/editor-handler.coffee
+++ b/lib/editor-handler.coffee
@@ -38,8 +38,11 @@ module.exports =
         e.preventDefault()
         return false
 
-      if @_mainMouseAndKeyDown(e)
+      if @_mainMouseAndOrKeyDown(e)
         @_resetState()
+        if @inputCfg.cursorToCrosshair
+          @editorElement.shadowRoot.querySelector(
+            '.lines').style.cursor = 'crosshair'
         @mouseStartPos = @_screenPositionForMouseEvent(e)
         @mouseEndPos   = @mouseStartPos
         e.preventDefault()
@@ -48,7 +51,7 @@ module.exports =
     onMouseMove: (e) =>
       if @mouseStartPos
         e.preventDefault()
-        if @_mainMouseDown(e)
+        if @_mainMouseAndOrKeyDown(e)
           @mouseEndPos = @_screenPositionForMouseEvent(e)
           return if @mouseEndPos.isEqual @mouseEndPosPrev
           @_selectBoxAroundCursors()
@@ -76,6 +79,9 @@ module.exports =
     # -------
 
     _resetState: ->
+      if @inputCfg.cursorToCrosshair
+        @editorElement?.shadowRoot.querySelector(
+          '.lines').style.cursor = ''
       @mouseStartPos = null
       @mouseEndPos   = null
 
@@ -101,8 +107,10 @@ module.exports =
     _mainMouseDown: (e) ->
       e.which is @inputCfg.mouseNum
 
-    _mainMouseAndKeyDown: (e) ->
-      if @inputCfg.selectKey
+    _mainMouseAndOrKeyDown: (e) ->
+      if @inputCfg.selectKey && (@inputCfg.mouseKeyLogicOperator == "Or")
+        @_mainMouseDown(e) or e[@inputCfg.selectKey]
+      else if @inputCfg.selectKey
         @_mainMouseDown(e) and e[@inputCfg.selectKey]
       else
         @_mainMouseDown(e)

--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -47,9 +47,9 @@ module.exports =
     cursorToCrosshair:
       title: "Change Cursor to Crosshair"
       description: "The mouse cursor will change to crosshair during column selection.
-        IF empty, the default will be used \"true\"."
+        IF empty, the default will be used \"false\"."
       type:'boolean'
-      default: true
+      default: false
 
     mouseButtonTrigger:
       title: "Mouse Button"

--- a/lib/sublime-select.coffee
+++ b/lib/sublime-select.coffee
@@ -44,6 +44,13 @@ inputCfg = defaultCfg
 module.exports =
 
   config:
+    cursorToCrosshair:
+      title: "Change Cursor to Crosshair"
+      description: "The mouse cursor will change to crosshair during column selection.
+        IF empty, the default will be used \"true\"."
+      type:'boolean'
+      default: true
+
     mouseButtonTrigger:
       title: "Mouse Button"
       description: "The mouse button that will trigger column selection.
@@ -51,6 +58,14 @@ module.exports =
       type: 'string'
       enum: (key for key, value of mouseNumMap)
       default: defaultCfg.mouseName
+
+    mouseKeyLogicOperator:
+      title: "Logic Operator"
+      description: "Should BOTH/EITHER \"Mouse Button\" And/Or \"Key\" trigger column selection?
+        If empty or \"Select Key\" is set to empty or none, the default will be used \"And\"."
+      type: 'string',
+      enum: ['And','Or']
+      default: 'And'
 
     selectKeyTrigger:
       title: "Select Key"
@@ -64,9 +79,15 @@ module.exports =
     @observers = []
     @editor_handler = null
 
+    @observers.push atom.config.observe "#{packageName}.cursorToCrosshair", (newValue) =>
+      inputCfg.cursorToCrosshair = newValue
+
     @observers.push atom.config.observe "#{packageName}.mouseButtonTrigger", (newValue) =>
       inputCfg.mouseName = newValue
       inputCfg.mouseNum = mouseNumMap[newValue]
+
+    @observers.push atom.config.observe "#{packageName}.mouseKeyLogicOperator", (newValue) =>
+      inputCfg.mouseKeyLogicOperator = newValue
 
     @observers.push atom.config.observe "#{packageName}.selectKeyTrigger", (newValue) =>
       inputCfg.selectKeyName = newValue


### PR DESCRIPTION
adding two settings options (and their corresponding functionality)

One to enable/disable switching the cursor to crosshair during selections.

The other allows the user to choose to trigger column selection using EITHER (new "feature") or BOTH (old behavior) the selected mouse button/key.

By default, the behavior of this package will not change. Users will have to go to settings & adjust manually.